### PR TITLE
fix: correct path for copying service file in README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If all outputs return `intel_pstate`, your system is compatible.
 2. Copy the `intel-noturbo.service` file to the systemd directory:
 
    ```bash
-   sudo cp systemd/intel-noturbo.service /etc/systemd/system/
+   sudo cp systemd/system/intel-noturbo.service /etc/systemd/system/
    ```
 
 3. Ensure the script has execution permissions:


### PR DESCRIPTION
This PR fixes a typo in the README instructions where the step to copy the service file had an incorrect path.
The original instruction incorrectly referenced systemd/intel-noturbo.service, missing the systemd/system subfolder.

The corrected command now properly references the full path